### PR TITLE
change docker image to public image in smarshsre

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,7 +16,7 @@ resources:
   - name: boshcli2
     type: registry-image
     source:
-      repository: afamuzoka/boshcli2
+      repository: smarshsre/data-services-boshcli2
       username: ((docker.username))
       password: ((docker.password))
       tag: latest


### PR DESCRIPTION
changing the docker image repository from afam's to our smarshsre public docker hub account