### PR TITLE
Update server.properties

### DIFF
--- a/jobs/kafka/templates/config/server.properties
+++ b/jobs/kafka/templates/config/server.properties
@@ -20,7 +20,7 @@
 broker.id=<%= spec.index+1 %>
 
 # Enable controlled shutdown to make sure that partition replicas are relocared to other brokers
-<% if_p("controlled_shutdown_enable") %>
+<% if_p("controlled_shutdown_enable") do %>
 controlled.shutdown.enable=<%= p("controlled_shutdown_enable") %>
 <% end %>
 


### PR DESCRIPTION
If statement formatting was missing a `do` and we were getting the same error on deployment attempt added `do` to the statement should fix it

```
                      L Error: Unable to render instance groups for deployment. Errors are:
  - Unable to render jobs for instance group 'kafka'. Errors are:
    - Unable to render templates for job 'kafka'. Errors are:
      - Error filling in template '(unknown)' (line (unknown): kafka/config/server.properties:25: syntax error, unexpected end, expecting end-of-input
      ;  end ; _erbout.<< "\n\n# Switch t...
         ^~~)
```